### PR TITLE
Update examples to valid schedules

### DIFF
--- a/docs/en/observability/synthetics-lightweight.asciidoc
+++ b/docs/en/observability/synthetics-lightweight.asciidoc
@@ -54,14 +54,14 @@ heartbeat.monitors:
   id: ping-myhost
   name: My Host Ping
   hosts: ["myhost"]
-  schedule: '@every 5s'
+  schedule: '@every 5m'
 - type: tcp
   id: myhost-tcp-echo
   name: My Host TCP Echo
   hosts: ["myhost:777"]  # default TCP Echo Protocol
   check.send: "Check"
   check.receive: "Check"
-  schedule: '@every 5s'
+  schedule: '@every 60s'
 ----
 
 [[synthetics-monitor-options]]


### PR DESCRIPTION
The current example shows schedules that won't be used, but will be rounded up, which is misleading